### PR TITLE
makefile: Add websocket server configuration

### DIFF
--- a/makefile
+++ b/makefile
@@ -143,6 +143,7 @@ W=emcc -s ASSERTIONS=0  -s WASM=1 \
 	--shell-file www/base.html \
 	-s EXTRA_EXPORTED_RUNTIME_METHODS='["ccall", "cwrap"]'\
 	-o www/$(EXEC).html -O3 $(CPPFLAG) $(MAIN) $(ENGINE_SRC) $(GAME_SRC) $(3RDP_SRC) \
+	--pre-js settings.js \
 
 
 #	-s USE_PTHREADS=1 

--- a/settings.js
+++ b/settings.js
@@ -1,0 +1,4 @@
+/* This configures the server that is used on any connection,
+   see emscripten/src/library_sockfs.js:178 */
+// Module['websocket'] = { url: 'ws://xb17.duckdns.org:1717' };
+Module['websocket'] = { url: 'ws://127.0.0.1:1717' };


### PR DESCRIPTION
A la hora de realizar conexiones de red emscripten las mueve todas hacia un mismo servidor (que por defecto es 'ws://'). Este servidor puede ser configurado agregando código javascript que configure el objeto `Module`. Este commit agrega una configuración simple que puede ser reemplazada a futuro (pero deja más en claro cómo funciona el networking dentro de este contexto).

### +info:
* [Emscripten Socket Implementation](https://github.com/emscripten-core/emscripten/blob/ac90f2252b9d1ad772ca549b6f633325debc554c/src/library_sockfs.js#L178)
* [Module object](https://emscripten.org/docs/api_reference/module.html)